### PR TITLE
Better support for promises in controllers

### DIFF
--- a/lib/router/layer.js
+++ b/lib/router/layer.js
@@ -55,7 +55,12 @@ Layer.prototype.handle_error = function handle_error(error, req, res, next) {
   }
 
   try {
-    fn(error, req, res, next);
+    result = fn(req, res, next);
+    if (result && typeof result.catch === 'function') {
+      result.catch(function(err) {
+        next(err);
+      });
+    }
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
Similar to how mocha infers that a promise was returned in a test, express controllers can automatically call the next handler with an error, if the promise is rejected.
